### PR TITLE
Dockerize and add Kubernetes manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 product/
 release/
+cockroachdb-servicebroker*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.10-alpine AS build
+RUN apk --no-cache add git make && \
+  go get -u github.com/golang/dep/cmd/dep
+WORKDIR $GOPATH/src/app
+COPY . $GOPATH/src/app
+RUN dep ensure && make build-static
+
+FROM scratch
+COPY --from=build /go/src/app/cockroachdb-servicebroker-static /cockroachdb-servicebroker-static
+ENTRYPOINT ["/cockroachdb-servicebroker-static"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+SOURCES=$(shell ls -1 *.go)
+CRDBSB_IMAGE ?= cockroachdb-servicebroker
+CRDBSB_TAG ?= 0.1
+
+CRDB_HOST ?= cockroachdb-public.default.svc.cluster.local
+CRDB_PORT ?= 26257
+CRDB_TOKEN ?= configure-me-token
+
+.PHONY: build
+build: deps cockroachdb-servicebroker
+
+.PHONY: build-static
+build-static: deps cockroachdb-servicebroker-static
+
+cockroachdb-servicebroker: $(SOURCES)
+	go build -o $@ $(SOURCES)
+
+cockroachdb-servicebroker-static: $(SOURCES)
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $@ $(SOURCES)
+
+.PHONY: docker-build
+docker-build:
+	docker build -t $(CRDBSB_IMAGE):$(CRDBSB_TAG) .
+
+.PHONY: docker-push
+docker-push: docker-build
+	docker push $(CRDBSB_IMAGE):$(CRDBSB_TAG)
+
+.PHONY: deps
+deps:
+	dep ensure
+
+.PHONY: deploy
+.EXPORT_ALL_VARIABLES: deploy
+deploy:
+	# $DOLLAR enables environment variables i.e. ${DOLLAR}${VAR}
+	DOLLAR='$$' envsubst < kubernetes/servicebroker.yaml | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -191,3 +191,52 @@ root@52.170.84.221:26257/> SELECT * FROM cf_gbccnddiddnnhfdolliklaolojgmceif.alb
 +--------------------------------------+---------+---------------------------+-------+-------------+----------------------------+------------+
 (29 rows)
 ```
+
+## Kubernetes (experimental)
+
+Kubernetes [Service Catalog](https://svc-cat.io/) introduces the Open Service
+Broker API to Kubernetes. This means that Service Brokers written for Cloud
+Foundry can be easily ported to Kubernetes.
+
+### Containerize
+
+The following commands will build a Docker container of the CockroachDB Service
+Broker and push it to your Docker Registry (make sure authentication is
+configured properly):
+
+```
+export CRDBSB_IMAGE=yourusername/crdbsb
+export CRDBSB_TAG=latest
+make docker-push
+```
+
+### Deploy
+
+Deployment has been successfully tested on [minikube
+0.28.2](https://github.com/kubernetes/minikube/releases/tag/v0.28.2) with the
+following extra configuration:
+
+```
+% minikube start --container-runtime docker \
+     --memory 8192 \
+     --cpus 2  \
+     --extra-config=apiserver.Authorization.Mode=RBAC
+```
+
+You will also need to install the [Service
+Catalog](https://svc-cat.io/docs/install/) on your Kubernetes cluster.
+
+Once your cluster is ready, make sure your kubectl context is configured
+correctly and issue the following commands to deploy the Service Broker:
+
+```
+export CRDBSB_IMAGE=yourusername/crdbsb
+export CRDBSB_TAG=latest
+export CRDB_HOST=cockroachdb-public.default.svc.cluster.local
+export CRDB_PORT=26257
+export CRDB_TOKEN=cockroachdb-cockroachdb-token-rs2kk
+make deploy
+```
+
+You can configure your CockroachDB cluster endpoint using the `CRDB_HOST`
+and `CRDB_PORT` environment variables.

--- a/kubernetes/clientapp.yaml
+++ b/kubernetes/clientapp.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: client-app01
+  name: client-app01
+spec:
+  containers:
+  - command:
+    - sleep
+    - "2147483648"
+    image: cockroachdb/cockroach:v2.0.3
+    imagePullPolicy: IfNotPresent
+    name: client-app01
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/secrets/mydb01-binding
+      name: mydb01-binding
+    env:
+    - name: "COCKROACH_URL"
+      valueFrom:
+        secretKeyRef:
+          name: mydb01-binding
+          key: uri
+  volumes:
+    - name: mydb01-binding
+      secret:
+        secretName: mydb01-binding
+    - emptyDir: {}
+      name: client-certs
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: mydb01-binding
+spec:
+  instanceRef:
+    name: mydb01
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: mydb01
+spec:
+  clusterServiceClassExternalName: cockroachdb
+  clusterServicePlanExternalName: default

--- a/kubernetes/servicebroker.yaml
+++ b/kubernetes/servicebroker.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: crdb-service-broker
+  labels:
+    app: crdbsb
+spec:
+  selector:
+    app: crdbsb
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: NodePort
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: crdb-service-broker
+  labels:
+    app: crdbsb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crdbsb
+  template:
+    metadata:
+      labels:
+        app: crdbsb
+    spec:
+      initContainers:
+        - name: ${CRDB_TOKEN}
+          command:
+          - /bin/ash
+          - -ecx
+          - /request-cert -namespace=${DOLLAR}{POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client
+            -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          image: cockroachdb/cockroach-k8s-request-cert:0.3
+          imagePullPolicy: IfNotPresent
+          name: init-certs
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /cockroach-certs
+            name: client-certs
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: ${CRDB_TOKEN}
+            readOnly: true
+      containers:
+      - name: crdbsb
+        image: ${CRDBSB_IMAGE}:${CRDBSB_TAG}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+          - name: SERVICES
+            value: '[
+              {
+                "id": "e2e250b5-73f8-45fd-9a7f-93c8dddc5f00",
+                "name": "cockroachdb",
+                "description": "CockroachDB service broker for creating cloud-native SQL databases.",
+                "bindable": true,
+                "plan_updateable": false,
+                "metadata": {
+                  "displayName": "CockroachDB",
+                  "longDescription": "CockroachDB service broker for creating cloud-native SQL databases.",
+                  "documentationUrl": "https://www.cockroachlabs.com/docs/",
+                  "supportUrl": "https://www.cockroachlabs.com/community/",
+                  "imageUrl": "https://www.cockroachlabs.com/images/CockroachLabs_Logo_Mark-lightbackground.svg"
+                },
+                "tags": ["cockroachdb", "database", "SQL", "cloud"]
+              }
+            ]'
+          - name: PRECONFIGURED_PLANS
+            value: '[
+              {
+                "name": "default",
+                "description": "Default",
+                "metadata": {
+                  "displayName": "Default"
+                },
+                "serviceID": "e2e250b5-73f8-45fd-9a7f-93c8dddc5f00",
+                "crdbHost": "${CRDB_HOST}",
+                "crdbPort": "${CRDB_PORT}"
+              }
+            ]'
+          - name: SECURITY_USER_NAME
+            value: user
+          - name: SECURITY_USER_PASSWORD
+            value: pass
+          - name: PGSSLKEY
+            value: /cockroach-certs/client.root.key
+          - name: PGSSLCERT
+            value: /cockroach-certs/client.root.crt
+        volumeMounts:
+        - mountPath: /cockroach-certs
+          name: client-certs
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: ${CRDB_TOKEN}
+          readOnly: true
+      volumes:
+      - emptyDir: {}
+        name: client-certs
+      - name: ${CRDB_TOKEN}
+        secret:
+          defaultMode: 420
+          secretName: ${CRDB_TOKEN}
+---
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ClusterServiceBroker
+metadata:
+  name: cockroachdb-service-broker
+spec:
+  url:  http://user:pass@crdb-service-broker.default


### PR DESCRIPTION
This PR introduces simple containerization driven by a Makefile and manifests to deploy the service broker on kubernetes.