### PR TITLE
Make the Service Broker work when CockroachDB is running in Secure Mode

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -142,7 +142,7 @@ func (sb *crdbServiceBroker) Bind(
 	}
 
 	options := make(url.Values)
-	options.Add("sslmode", "disable")
+	options.Add("sslmode", "require")
 
 	credMap := map[string]interface{}{
 		"host":     plan.CRDBHost,

--- a/plans.go
+++ b/plans.go
@@ -119,7 +119,7 @@ func addPlan(p Plan) {
 	}
 
 	options := make(url.Values)
-	options.Add("sslmode", "disable")
+	options.Add("sslmode", "require")
 
 	p.crdb, err = sql.Open(
 		"postgres",


### PR DESCRIPTION
In order to provision Service Instances we need to `CREATE USER WITH PASSWORD`. This is currently possible only when cockroachdb is running in secure mode.

This PR sets the `sslmode` option to `require` as specified in the [CockroachDB docs](https://www.cockroachlabs.com/docs/stable/connection-parameters.html#secure-connections-with-urls)